### PR TITLE
Better layout for home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+
+<div class="home">
+  {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {%- endif -%}
+
+  {{ content }}
+
+    <h2 class="post-list-heading">Materiaali</h2>
+    <ul class="post-list">
+      {%- for post in site.tags.material -%}
+      <li>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+      </li>
+      {%- endfor -%}
+    </ul>
+
+    <h2 class="post-list-heading">Info</h2>
+    <ul class="post-list">
+      {%- for post in site.tags.info -%}
+      <li>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+      </li>
+      {%- endfor -%}
+    </ul>
+
+    <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+
+</div>

--- a/_posts/1969-28-12-departments-systems.markdown
+++ b/_posts/1969-28-12-departments-systems.markdown
@@ -3,6 +3,7 @@ layout: material
 title: "The CS department's systems"
 date: 1969-12-28 00:00:05 +0200
 permalink: /departments-systems/
+tag: eng
 ---
 
 - If you are a CS major or minor, please activate your account according to [these](https://www.cs.helsinki.fi/en/compfac/user-accounts) instructions.

--- a/_posts/1969-28-12-exam.markdown
+++ b/_posts/1969-28-12-exam.markdown
@@ -3,6 +3,7 @@ layout: material
 title: "Exam and grading"
 date: 1969-12-28 00:00:10 +0200
 permalink: "/exam/"
+tag: eng
 ---
 
 One must pass the exam in order to receive a grade from the course. The exam is taken in Moodle, where you log in using your University account.

--- a/_posts/1969-28-12-ohjeita-googlettamiseen.markdown
+++ b/_posts/1969-28-12-ohjeita-googlettamiseen.markdown
@@ -3,6 +3,7 @@ layout: material
 title: "Ohjeita tehokkaaseen googlettamiseen"
 date: 1969-12-28 00:05:00 +0200
 permalink: "/ohjeita-googlettamiseen/"
+tag: info
 ---
 
 Tällä kurssilla tulee monta kertaa vastaan tehtävä, jossa kehotetaan selvittämään itse, miten jonkin asian voi tehdä. Tiedon hakeminen itsenäisesti Internetistä on olennainen osa ohjelmoijan työtä: keneltäkään harvoin odotetaan, että tietyn komennon parametrien tai metodien nimet muistettaisiin ulkoa. Oleellista on kyetä etsimään tarvittaessa luotettavaa tietoa Internetistä.

--- a/_posts/1969-28-12-osa-1.markdown
+++ b/_posts/1969-28-12-osa-1.markdown
@@ -3,6 +3,7 @@ layout: post
 title: 'Osa 1 - Komentorivi'
 date: 1969-12-28 00:04:00 +0200
 permalink: /komentorivi/
+tag: material
 ---
 
 Tästä alkaa ensimmäisen viikon materiaali. Ensimmäisen viikon keskeisin tavoite on tutustua komentoriviin Unix-tyyppisessä ympäristössä.

--- a/_posts/1969-28-12-osa-1.markdown
+++ b/_posts/1969-28-12-osa-1.markdown
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: material
 title: 'Osa 1 - Komentorivi'
 date: 1969-12-28 00:04:00 +0200
 permalink: /komentorivi/

--- a/_posts/1969-28-12-osa-2.markdown
+++ b/_posts/1969-28-12-osa-2.markdown
@@ -3,6 +3,7 @@ layout: post
 title: 'Osa 2 - Versionhallinta: Git ja Github'
 date: 1969-12-28 00:03:00 +0200
 permalink: /git/
+tag: material
 ---
 
 # Oppimistavoitteet

--- a/_posts/1969-28-12-osa-2.markdown
+++ b/_posts/1969-28-12-osa-2.markdown
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: material
 title: 'Osa 2 - Versionhallinta: Git ja Github'
 date: 1969-12-28 00:03:00 +0200
 permalink: /git/

--- a/_posts/1969-28-12-osa-3.markdown
+++ b/_posts/1969-28-12-osa-3.markdown
@@ -3,6 +3,7 @@ layout: material
 title: 'Osa 3 - Staattiset verkkosivut'
 date: 1969-12-28 00:02:00 +0200
 permalink: /verkkosivut/
+tag: material
 ---
 
 # Oppimistavoitteet

--- a/_posts/1969-28-12-osaston-jarjestelmat.markdown
+++ b/_posts/1969-28-12-osaston-jarjestelmat.markdown
@@ -3,6 +3,7 @@ layout: material
 title: 'Osaston järjestelmät'
 date: 1969-12-28 00:00:00 +0200
 permalink: /osaston-jarjestelmat/
+tag: info
 ---
 
 - Mikäli olet tietojenkäsittelytieteen pää- tai sivuaineopiskelija, aktivoi CS-tunnuksesi seuraavan sivun [ohjeiden](https://www.cs.helsinki.fi/tietotekniikka/k-ytt-luvat) mukaan.

--- a/_posts/1969-28-12-paja.markdown
+++ b/_posts/1969-28-12-paja.markdown
@@ -3,6 +3,7 @@ layout: material
 title: "Paja"
 date: 1969-12-28 00:05:00 +0200
 permalink: "/paja/"
+tag: info
 ---
 
 Pajalla tarkoitetaan määrättyä hetkeä, jolloin kurssin assistentit ovat paikalla luokkahuoneessa, jonne opiskelijat voivat halutessaan tulla tekemään kurssin tehtäviä ja esittämään kysymyksiä. Pajaan ei tarvitse ilmoittautua, eikä paikalla tarvitse olla määrättyä aikaa: tarkoitus on, että opiskelija voi esittää matalalla kynnyksellä kysymyksiä ja esimerkiksi tehdä yhteistyötä toisten opiskelijoiden kanssa. Paja on erinomainen tapa opiskella, ja suosittelemme sitä lämpimästi.

--- a/_posts/1969-28-12-tentti.markdown
+++ b/_posts/1969-28-12-tentti.markdown
@@ -3,6 +3,7 @@ layout: material
 title: "Tentti ja arvostelu"
 date: 1969-12-28 00:01:00 +0200
 permalink: "/tentti/"
+tag: info
 ---
 
 Hyväksytty suoritus tentistä on edellytys kurssin läpipääsyyn. Verkkotentti suoritetaan Moodle-oppimisympäristössä, johon kirjaudutaan yliopiston käyttäjätunnuksilla.

--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: home
+list_title: Materiaali
 ---
 
 <h3>A link to the English page is in the upper right corner</h3>
@@ -23,7 +24,7 @@ Tehtäviä tekemällä ansaitsee laskaripisteitä, jotka lasketaan mukaan kurssi
 
 ## Tukikanavat
 
-Kurssilla on kaksi tukikanavaa: Syksyn 2019 ensimmäisen periodin ajan järjestetään pajaohjausta, jolloin opiskelijoiden on mahdollista tulla tekemään tehtäviä osaston tiloihin, ja saada halutessaan apua kurssin assistenteilta. Lue lisää pajasta, ja sen aikatauluista [täältä](/paja).
+Kurssilla on kaksi tukikanavaa: Syksyn 2018 ensimmäisen periodin ajan järjestetään pajaohjausta, jolloin opiskelijoiden on mahdollista tulla tekemään tehtäviä osaston tiloihin, ja saada halutessaan apua kurssin assistenteilta. Lue lisää pajasta, ja sen aikatauluista [täältä](/paja).
 
 Kurssilla on myös sähköinen tukikanava, joka on sillattu IRCistä telegrammiin. 
 
@@ -48,16 +49,6 @@ Kurssin suorittaminen vaatii muutaman ohjelman asentamista koneelle. Mikäli et 
 Jos teet tehtäviä kotikoneella, ja olet läsnäoleva yliopisto-opiskelija, asenna ensin [Eduroam](https://www.eduroam.org/what-is-eduroam/), jolla pääset internetiin Helsingin yliopiston kampusalueilla. Helpdeskillä on sille [ohjeet](https://helpdesk.it.helsinki.fi/ohjeet/kirjautuminen-ja-yhteydet/verkkoyhteydet/eduroam-verkon-asennus-asetustiedoston-avulla). Suosi aina Eduroamia yliopiston toisen verkon, HUPnetin yli. Internetin käyttö Eduroamin yli on turvallisempaa, ja se on saatavilla kampusalueilla myös ulkomailla.
 
 **Mikäli olet tietojenkäsittelytieteen pää- tai sivuaineopiskelija, aktivoi CS-tunnuksesi seuraavan sivun [ohjeiden](https://www.cs.helsinki.fi/tietotekniikka/k-ytt-luvat) mukaan ennen materiaalin lukemista.**
-
-## Linkit
-
-<a href="/tentti">Tentti ja arvostelu</a>
-
-Tähän tulee kurssin alettua linkki kurssialueeseen Moodlessa.
-
-<a href="/osaston-jarjestelmat">Osaston IT-järjestelmät</a>
-
-<a href="/paja">Pajasta</a>
 
 <h2>Ohjeita materiaalin lukemiseen</h2>
 


### PR DESCRIPTION
* Adds tags to material, posts are grouped by tags on the home page, e.g `tag: material` goes under material heading
* Removed links section in favor of info tag
* English is its own tag, and not shown on Finnish front page
* Fix 2019 typo
* Remove timestamps
* Fix layouts in first two parts to `material`

Thoughts?
