### PR TITLE
Remove default Jekyll social media handles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   Tietokone-työvälineenä
 baseurl: '' # the subpath of your site, e.g. /blog
 url: '' # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username: jekyll
+twitter_username:
+github_username:
 favicon: /favicon.ico
 
 # Build settings


### PR DESCRIPTION
The footer includes the default Jekyll Twitter & GitHub handles from `_config.yml`. This commit removes those handles, which in turn removes the social links from the footer.

![image](https://user-images.githubusercontent.com/21111572/44538311-9a4bc000-a709-11e8-9aab-e11827bd921a.png)
