### PR TITLE
Fix CSS property name for text-transform

### DIFF
--- a/_posts/1969-28-12-osa-3.markdown
+++ b/_posts/1969-28-12-osa-3.markdown
@@ -610,7 +610,7 @@ CSS-ominaisuuksia on olemassa valtavasti ja emme ehdi millään käydä niitä k
 
 `text-decoration: none | underline | overline | line-through | blink | inherit`, mahdollistaa yleisimmät tekstin muokkaustavat, esimerkiksi alleviivauksen.
 
-`text-transformation: none | capitalize | uppercase | lowercase`, mahdollistaa koko tekstin pienellä/suurella kirjoitettuna, vaikka tekstin sisällössä olisi erinkokoisia kirjaimia.
+`text-transform: none | capitalize | uppercase | lowercase`, mahdollistaa koko tekstin pienellä/suurella kirjoitettuna, vaikka tekstin sisällössä olisi erinkokoisia kirjaimia.
 
 `line-height`, rivinkorkeudella voi säätää tekstien rivien välistä etäisyyttä. Tämä ominaisuus vaikuttaa vain tekstiin. Anna tälle arvot pikseleinä tai prosentteina.
 


### PR DESCRIPTION
Fix CSS property name in part 3, section "CSS:n käytetyimmät ominaisuudet": https://www.w3schools.com/cssref/pr_text_text-transform.asp