### PR TITLE
Tarkenna tab-täydennys-osiota

### DIFF
--- a/_posts/1969-28-12-osa-1.markdown
+++ b/_posts/1969-28-12-osa-1.markdown
@@ -208,7 +208,9 @@ Voit merkata tämän tehtävän tehdyksi, kun olet käynyt läpi alun esimerkin 
  Luo komentoriviltä kansio nimeltä "lapio" kotihakemistoosi. Varmista että loit kansion komennolla <code>ls</code>.
 </div>
 
-Jos olet tottunut käyttämään graafista käyttöliittymää, mietit luultavasti nyt, miten hidasta ja raskasta komentorivin käyttäminen varmasti on. Kyseessä on luonnollisesti tottumiskysymys, mutta sen lisäksi komentorivillä on olemassa kirjoittamista nopeuttava seikka: tab-täydennys. Tab-täydennys täydentää nykyisen kansion tiedostojen nimiä parametreiksi sekä (joskus, ohjelmasta riippuen) ohjelmien komentoja.
+<h2>Komentorivin käyttöä nopeuttavia seikkoja</h2>
+
+Jos olet tottunut käyttämään graafista käyttöliittymää, mietit luultavasti nyt, miten hidasta ja raskasta komentorivin käyttäminen varmasti on. Kyseessä on luonnollisesti tottumiskysymys, mutta sen lisäksi komentorivillä on olemassa kirjoittamista nopeuttava seikka: tab-täydennys. Tab-täydennys osaa täydentää esimerkiksi tiedostojen nimiä parametreiksi sekä (joskus, ohjelmasta riippuen) ohjelmien komentoja.
 
 Kokeile tab-täydennystä kirjoittamalla kotihakemistossa `cd D`, ja painamalla sen jälkeen tabular-näppäintä (löytyy näppämistöstä caps-lockin yläpuolelta) pari kertaa. Terminaaliin tulostuu kaikki kotihakemiston D-kirjaimella alkavat hakemistot, ainakin siis "Downloads" ja "Documents". Oletetaan, että haluat siirtyä Downloads-kansioon. Tällöin riittää kirjoittaa cd-komennon parametriksi vain `Dow` ja painaa tab-näppäintä, jonka jälkeen Downloads-kansion nimi täydennetään komennon parametriksi (olettaen että kotihakemistossasi ei ole mitään muuta kansiota, jonka nimi alkaisi merkkijonolla `Dow`).
 
@@ -300,6 +302,11 @@ kissa2.jpg
 Muista, että komentorivi näyttää sinulle koko ajan nykyisen kansiosi polun suhteessa kotihakemistoosi. Tämä helpottaa tiedostojen seassa navigointia ja polkujen kirjoittamista.
 </div>
 
+<div class="note">
+Muista käyttää tab-taydennystä! Kokeile aina ennen kuin kirjoitat kokonaisen kansion tai tiedostonnimen, pystytkö täydentämään nimen suoraan painamalla tab-näppäintä.
+</div>
+
+
 <div class="exercise">
 <h3>Tehtävä 5: Tiedostonhallinnan harjoittelu 1 {% include points.html text="5%" %}</h3>
 
@@ -345,6 +352,7 @@ Kun olet luonut alkutilanteen, muuta se komennoilla <code>mv</code> ja <code>cp<
 Huomaa, että kiusallinen kirjoitusvirhe tiedoston <code>kmntorivi.txt</code> nimessä on korjattu. Tiedosto <code>javasta.txt</code> on uudelleennimetty ja siirretty kansioon <code>ohpe</code>.
 <img src="/assets/lapio_goal.png" alt="Lopputilanne"/>
 
+Muista käyttää tab-täydennystä!
 </div>
 
 <div class="exercise">

--- a/_posts/1969-28-12-part-1.markdown
+++ b/_posts/1969-28-12-part-1.markdown
@@ -212,6 +212,8 @@ You can mark this exercise as done after you've gone through the previous exampl
 Create a folder named "lapio" in your home folder. Make sure you created the folder correctly by checking the output of <code>ls</code>.
 </div>
 
+<h2>Tips for using the command line more efficiently</h2>
+
 If you're used to using the graphical file browser, you're probably wondering how slow and inefficient using the command line must be. It is naturally a question of custom, but there's also one feature on the command line, which makes writing commands a lot faster: tab completion. With the tab key you can automatically complete filenames and sometimes even commands, depending on the program.
 
 Let's try tab completion. Nagivate to your home folder. First, write down `cd D` and press the tab key (located above <kbd>CAPS LOCK</kbd>) a couple of times. All the directories starting with the letter "D" should be printed to the command line, including at least `Downloads` and `Documents`.
@@ -303,7 +305,7 @@ cat2.jpg
 ```
 
 <div class="note">
-<strong>Remember to use tab completion when writing paths!</strong> In addition, the command line shows you the path of the current folder with respect to your home folder. This makes it easier to navigate and write paths in the command line.
+<strong>Remember to use tab completion when writing paths!</strong> Always check if you can complete the next component of the path automatically before writing it yourself. In addition, the command line shows you the path of the current folder with respect to your home folder. This makes it easier to navigate and write paths in the command line.
 </div>
 
 <div class="exercise">
@@ -325,6 +327,8 @@ First create the <code>school</code> folder and move inside it. Then create the 
 You can create a text file by opening it in a text editor and saving, or with the command <code>touch</code>.</p>
 
 Make sure you've created all the proper files and folders with <code>ls</code>.
+
+Remember to use tab completion!
 </div>
 
 


### PR DESCRIPTION
Entisellään materiaali antoi ymmärtää, että tabilla voi täydentää vain nykyisen kansion nimiä, vaikka se toimii myös poluille yleisemmin. Tämä johtui todennäköisesti siitä, että polut esiteltiin tab-täydennyksen jälkeen, joten polku-termin käyttö ei välttämättä ole järkevää. Ratkaisuna korjasin tab-täydennys-esittelytekstiin jotain hieman yleisempää, ja lisäsin polkujen yhteyteen muistutuksen täydennyksen käyttämisestä.