### PR TITLE
Fix adding key to ssh-agent 

### DIFF
--- a/_posts/1969-28-12-about-googling.markdown
+++ b/_posts/1969-28-12-about-googling.markdown
@@ -16,7 +16,7 @@ English is the primary language of programming, and so you should see more resul
 
 ## You can only use key words if you wish.
 
-Nowadays Google is quite good at interpreting complete sentences. However, sometimes a full sentence may distort the results, as it contains many irrelevant words. You can also just use key words in your searches, like  "Ubuntu command line move to folder" instead of "How to move to a folder in Ubuntu command line" sijaan. 
+Nowadays Google is quite good at interpreting complete sentences. However, sometimes a full sentence may distort the results, as it contains many irrelevant words. You can also just use key words in your searches, like  "Ubuntu command line move to folder" instead of "How to move to a folder in Ubuntu command line". 
 
 ## Use context words.
 
@@ -24,7 +24,7 @@ If you're looking for an answer to a programming problem, it's a good idea to st
 
 ## Check several sources if possible.
 
-When it comes to programming, oftentimes it is easier to find answers from fellow codes on the internet instead of the official documentation. Obviously the official docs are always the best source for information, but if none are available, or you don't understand them, the best way to be sure of the reliability of an answer is to check as many sources as possible. However, it is good to know that sometimes information circles around the Internet, meaning that several places have gotten their information from the same, erronous source.
+When it comes to programming, oftentimes it is easier to find answers from fellow programmers on the Internet instead of the official documentation. Obviously the official docs are always the best source for information, but if none are available, or you don't understand them, the best way to be sure of the reliability of an answer is to check as many sources as possible. However, it is good to know that sometimes information circles around the Internet, meaning that several places have gotten their information from the same, erronous source.
 
 ## Use <a href="https://stackoverflow.com/">StackOverflow</a>.
 
@@ -38,11 +38,11 @@ StackOverflow is a forum named after an error message, and created as a support 
 
 ## Use the proper Google search syntax.
 
-Google actually supports a variety of different search operators. Using a hyphen ("-") in front of a word will filter out irrelevatn words. For example, if you are searching for something related to the programming language Python, (and your search is history is not filled with programming related searches), it might be a good idea to search for "python -snake" for optimal results. If you want to search for a specific sentence, use quotation marks around it. YOu can find more info [here](https://support.google.com/websearch/answer/2466433).
+Google actually supports a variety of different search operators. Using a hyphen ("-") in front of a word will filter out irrelevatn words. For example, if you are searching for something related to the programming language Python, (and your search is history is not filled with programming related searches), it might be a good idea to search for "python -snake" for optimal results. If you want to search for a specific sentence, use quotation marks around it. You can find more info [here](https://support.google.com/websearch/answer/2466433).
 
 ## Make use of error messages.
 
-If your problem relates to a specific program example, you are usually displayed some sort of error message. Error messages are extremely valuable when debugging, as they are in fact designed to give out useful information about a specific problem. First of all, make sure to read the error message throughoutly yourself, as they may be quite easily understandable, depending on the program. However, if you don't understand the message or the problem, you can simply Google the error message itself -- this will usually take you to GitHub, where someone has created an issue of the problem. Make sure to remove all identifying aspects of the message, such as file paths, as they will distort the search results. Try to find the essential part of the error message, that you think other people might have searched for as well.
+If your problem relates to a specific program, you will usually be shown some error message. Error messages are extremely valuable when debugging, as they are in fact designed to give out useful information about a specific problem. First of all, **make sure to read the error message throughoutly yourself**, as they may be quite easily understandable, depending on the program. However, if you don't understand the message or the problem, you can simply Google the error message itself -- this will usually take you to GitHub, where someone has created an issue of the problem. Make sure to remove all identifying aspects of the message, such as file paths, as they will distort the search results. Try to find the essential part of the error message, that you think other people might have searched for as well.
 
 ## Find similar problems.
 

--- a/_posts/1969-28-12-osa-1.markdown
+++ b/_posts/1969-28-12-osa-1.markdown
@@ -589,7 +589,7 @@ Jotta et joudu kirjoittamaan salasanaa joka kerralla, kannattaa yksityinen avain
 
 ```
 # varmistetaan, että ssh-agentti on toimintavalmiudessa
-eval `ssh-agent`
+eval $(ssh-agent -s)
 # olettaen, ettet muuttanut yksityisen avaimen polkua sitä luodessasi
 # muuten anna argumentiksi yksityisen avaimen polku
 ssh-add

--- a/_posts/1969-28-12-part-1.markdown
+++ b/_posts/1969-28-12-part-1.markdown
@@ -633,7 +633,7 @@ In order not to rewrite the passoword each time you want to log in, you might wa
 
 ```
 # make sure the agent is ready
-eval `ssh-agent`
+eval $(ssh-agent -s)
 # assuming you are using the default path
 # otherwise provide the path to the private key
 ssh-add

--- a/_posts/1969-28-12-part-1.markdown
+++ b/_posts/1969-28-12-part-1.markdown
@@ -625,11 +625,11 @@ It's also a good idea to see how <code>scp</code> works if the target file doesn
 </i>
 </div>
 
-The copying of the public file can also be delegated to the command [ssh-copy-id](https://www.ssh.com/ssh/copy-id).
+Copying the public key file can also be delegated to the command [ssh-copy-id](https://www.ssh.com/ssh/copy-id).
 
 The authentication works correctly, when creating an SSH connection you can login using the password set for the SSH key pair.
 
-In order not to rewrite the passoword each time you want to log in, you might want to add the password to an ssh agent. Then the password has to only be written once you've logged out of the system. This can happen using two commands.
+In order not to rewrite the passoword each time you want to log in, you might want to add the password to the ssh agent. Having done that, the password has to only be written once you've logged out of the system. This can be done using two commands.
 
 ```
 # make sure the agent is ready
@@ -642,7 +642,7 @@ ssh-add
 <div class="exercise">
 <h3>Exercise 11: SSH connection {% include points.html text="10%" %}</h3>
 
-Create an SSH key pair on your computer. Then enable logging in to the department's servers with the key when establishing an SSH connection. Then test out the key pair. 
+Create an SSH key pair on your computer. Then enable logging in to the department's servers with the key when establishing an SSH connection. Finally test out the key pair. 
 
 If possible, do this using other than the department's computers. If you don't have access to the department's servers, i.e. you do not have a university account, you can mark the exercise done after generating the SSH key pair.
 


### PR DESCRIPTION
Several people reported issues using the back tick syntax, and so the new instructions are stolen from the updated GitHub instructions. 