### PR TITLE
Fix typo and translate 969-28-12-en.markdown

### DIFF
--- a/_posts/1969-28-12-en.markdown
+++ b/_posts/1969-28-12-en.markdown
@@ -9,7 +9,7 @@ tag: home-eng
 <h1 id="main-title">Welcome to the course page of the course Computing tools for CS studies, or Lapio </h1>
 {%- assign course = site.data.data.course -%}
 
-This course is primarly designed for CS freshmen, and its purpose is to go through the basics of the command line in a Unix-like system, using Git for version control, and building a static website using HTML and CSS. The course's nickname "lapio" is Finnish, and it simply means "shovel", as the course teaches the basic use of the essential tools in Computer Science.
+This course is primarily designed for CS freshmen, and its purpose is to go through the basics of the command line in a Unix-like system, using Git for version control, and building a static website using HTML and CSS. The course's nickname "lapio" is Finnish, and it simply means "shovel", as the course teaches the basic use of the essential tools in Computer Science.
 The course is passed with an online exam, which is held in [Moodle]({{course.moodle}}), an e-learning environment widely used in the University. In order to enter the course  in Moodle, you will need to enter a key, which is is **lapio-on-tyovaline**. The exam questions are primarly based on the material provided on this Website, which is divided into three sections, each covering a different subject: the command line, Git and Github, and static websites.
 
 If you have experience of using the command line, Git and HTML/CSS, you are free to take the exam right away, without reading the material or doing the exercises. At the start of each section there is a list of learning goals, which will help you determine whether you should read the material or not. Even if you don't read the material, make sure to go through [this page](/departments-systems) as it provides important information about the department's IT systems.
@@ -69,7 +69,7 @@ Passing the course on your personal computer might require installing some softw
 If you are working on a personal computer, you should install [Eduroam](https://www.eduroam.org/what-is-eduroam/), which will grant you a secure access to the Internet while on campus. [Here](https://helpdesk.it.helsinki.fi/en/instructions/logging-and-connections/networks/setting-eduroam-installer-package) are the instructions. Note that you can also use it overseas and on mobile devices.
 
 
-## Ohjeita materiaalin lukemiseen
+## Material reading guides
 
 The percentage after an exercise states what is its relative weight of that weeks exercises.
 


### PR DESCRIPTION
- Changed "primarly" to "primarily" (line 12)
- Translate "Ohjeita materiaalin lukemiseen" to "Material reading guides"